### PR TITLE
AT2-43 Stub calls to MaxIV Authentication server for MVP

### DIFF
--- a/src/actions/api/user.js
+++ b/src/actions/api/user.js
@@ -1,8 +1,13 @@
 export default {
   async preloadUser() {
     try {
-      const res = await fetch("/auth/user");
-      const user = await res.json();
+      // AT2-43 - Stub out MaxIV A&A Layer for the moment
+      // as we don't have an A&A Server.
+      //
+      // TODO: Put A&A back in
+      // const res = await fetch("/auth/user");
+      // const user = await res.json();
+      const user = {username : "Pre-loaded User"};
       return user;
     } catch (err) {
       return null;
@@ -10,29 +15,35 @@ export default {
   },
 
   async login(username, password) {
-    const init = {
-      method: "POST",
-      body: JSON.stringify({ username, password }),
-      headers: {
-        "Content-Type": "application/json; charset=utf-8"
-      }
-    };
+    // AT2-43 deliberate stub of A&A
+    // TODO: Put A&A back in
+    return username;
+    // const init = {
+    //   method: "POST",
+    //   body: JSON.stringify({ username, password }),
+    //   headers: {
+    //     "Content-Type": "application/json; charset=utf-8"
+    //   }
+    // };
 
-    try {
-      const res = await fetch("/auth/login", init);
-      return res.ok ? username : null;
-    } catch (err) {
-      return null;
-    }
+    // try {
+    //   const res = await fetch("/auth/login", init);
+    //   return res.ok ? username : null;
+    // } catch (err) {
+    //   return null;
+    // }
   },
 
   async logout() {
-    try {
-      const init = { method: "POST" };
-      const res = await fetch("/auth/logout", init);
-      return true;
-    } catch (err) {
-      return false;
-    }
+    // AT2-43 deliberate stub of A&A
+    // TODO: Put A&A back in
+    return true;
+    // try {
+    //   const init = { method: "POST" };
+    //   const res = await fetch("/auth/logout", init);
+    //   return true;
+    // } catch (err) {
+    //   return false;
+    // }
   }
 };

--- a/src/reducers/user.ts
+++ b/src/reducers/user.ts
@@ -34,7 +34,9 @@ type UserAction =
   | IPreloadUserFailedAction;
 
 const initialState = {
-  awaitingResponse: true,
+  // TODO: Having awaitingResponse as true seemed to break the login paths
+  // need to investigate further when we un-stub A&A
+  awaitingResponse: false,
   loginFailed: false
 };
 


### PR DESCRIPTION
This change stubs the requests to the Max IV authentication server - but still leaves the login, logout and checking whether a user is logged in and who they are routes untouched in the rest of the webjive code.

After this change users should be able to 'login' on the UI with any credentials and 'logout' and on the commands screen it will acknowledge that they are a logged in user.